### PR TITLE
hotfix: remove broadcast in CUDA kernels

### DIFF
--- a/src/models/acopf/acopf_init_solution_gpu.jl
+++ b/src/models/acopf/acopf_init_solution_gpu.jl
@@ -37,7 +37,10 @@ function init_branch_bus_kernel_one_level(n::Int, line_start::Int, rho_va::Float
         v[pij_idx+6] = 0.0
         v[pij_idx+7] = 0.0
 
-        rho[pij_idx+4:pij_idx+7] .= rho_va
+        rho[pij_idx+4] = rho_va
+        rho[pij_idx+5] = rho_va
+        rho[pij_idx+6] = rho_va
+        rho[pij_idx+7] = rho_va
     end
 
     return

--- a/src/models/mpec/mpec_init_solution_gpu.jl
+++ b/src/models/mpec/mpec_init_solution_gpu.jl
@@ -46,7 +46,10 @@ function mpec_init_solution_line(
         v[pij_idx+6] = 0.0
         v[pij_idx+7] = 0.0
 
-        rho[pij_idx+4:pij_idx+7] .= rho_va
+        rho[pij_idx+4] = rho_va
+        rho[pij_idx+5] = rho_va
+        rho[pij_idx+6] = rho_va
+        rho[pij_idx+7] = rho_va
     end
     return
 end


### PR DESCRIPTION
As far as I know, we should avoid using the broadcast operator inside a GPU kernel. 