### PR TITLE
Add support for KA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
+      - run: julia --project deps/deps.jl
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
       - run: julia --project=docs/ docs/make.jl
@@ -48,5 +49,6 @@ jobs:
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
+      - run: julia --project deps/deps.jl
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 CUDA = "3.4"
-ExaTron = "1"
+ExaTron = "2"
 FileIO = "1.14"
 julia = "1.7"
 MPI = "0.19"

--- a/deps/deps.jl
+++ b/deps/deps.jl
@@ -1,0 +1,4 @@
+using Pkg
+
+exatron = Pkg.PackageSpec(url="https://github.com/exanauts/ExaTron.jl.git", rev="ms/ka")
+Pkg.add([exatron])


### PR DESCRIPTION
This is a draft PR.

So far in this PR ExaAdmm.jl uses ExaTron v2.0 with KA support. It remains to port the kernels in ExaAdmm to KA. https://github.com/exanauts/ExaAdmm.jl/issues/33