### PR TITLE
Bump AMDGPU and Julia version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        julia-version: ['1.7']
+        julia-version: ['1.8']
         julia-arch: [x64]
 
     steps:
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        julia-version: ['1.7']
+        julia-version: ['1.8']
         julia-arch: [x64]
 
     steps:

--- a/Project.toml
+++ b/Project.toml
@@ -18,10 +18,10 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-AMDGPU = "0.3"
+AMDGPU = "0.4"
 CUDA = "3.4"
 ExaTron = "2"
 FileIO = "1.14"
 KernelAbstractions = "0.8"
 MPI = "0.19"
-julia = "1.7"
+julia = "1.8"


### PR DESCRIPTION
This resolves `GPUCompiler.jl` version conflict and allows using `CUDA.jl` 3.12.